### PR TITLE
Add helm-check command

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 GitHub, Inc. and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# This is a public repository, be extra cautious on what you post on it!
+
 This repository acts as a collection of GWI specific Actions
 
 Please check GA's own Marketplace for an existing solution before you create your own. https://github.com/marketplace?type=actions 
+
+# License
+The scripts and documentation in this project are released under the [MIT License](https://github.com/GlobalWebIndex/github-actions/blob/main/LICENCE)

--- a/helm-check/Dockerfile
+++ b/helm-check/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcr.io/gwi-host-net/drone-helm:v1
+
+LABEL version="1.0.0"
+LABEL repository="https://github.com/GlobalWebIndex/github-actions"
+LABEL maintainer="GWI's DevOps team"
+
+LABEL com.github.actions.name="GitHub Action for Helm secret templates validation"
+LABEL com.github.actions.description="Checks if helm templates are valid, using the helm secret command"
+LABEL com.github.actions.icon="cloud"
+LABEL com.github.actions.color="blue"
+
+ADD entrypoint.sh /entrypoint.sh
+CMD ["bash", "/entrypoint.sh"]

--- a/helm-check/README.md
+++ b/helm-check/README.md
@@ -1,0 +1,49 @@
+# Helm check GA plugin
+
+## What it does
+
+GA plugin that validates your Helm charts against kubeval and kube-score. It uses `helm secrets template` to generate the Helm templates, so it is possible to integrate with GCP in case KMS is being used for your secrets.
+
+## Usage
+
+Just use the following two environmental variables as inputs
+
+```sh
+HELM_CHART_PATH:  <path of your Helm chart>
+GCP_CREDENTIALS: <SA to use for Helms secrets> # This is not needed if you don't have secrets.yaml in your Helm files
+KUBERNETES_VERSION: Kubernetes version to check against, default: 1.21
+HELM_VALUES: Comma separated Values passed to Hlem through the --set-string attribute, default: ""
+HELM_VALUES_FILES: Comma separated value files for your Helm charts, default: ""
+KUBESCORE_PARAMS: Parameters to add to kubescore
+```
+
+## Usage example
+
+```sh
+name: default
+on:
+  push: {}
+
+jobs:
+  helm_check:
+    runs-on: [ <tages for your self hosted runners> ]
+    container:
+      image: ghcr.io/catthehacker/ubuntu:act-latest
+    steps:
+    - uses: actions/checkout@v3 # Checkout your code
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: helm-check # Run this plugin
+      uses: GlobalWebIndex/github-actions/helm-check
+      env:
+        HELM_CHART_PATH: <path to your helm charts>
+        GCP_CREDENTIALS: ${{ secrets.SA_NAME}}
+```
+
+## Test it locally
+
+In your local repo, create `./.github/workflows/main.yml` and add the code from the example above, making sure you fill all the required info. Then run the following command in order to test this with [act](https://github.com/nektos/act)
+
+```sh
+act --container-architecture linux/amd64 -s GITHUB_TOKEN -s SA_NAME --workflows ./.github/workflows/main.yml
+```

--- a/helm-check/entrypoint.sh
+++ b/helm-check/entrypoint.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+TEST_COMMIT_SHA="test"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-"1.21"}"
+HELM_CHART_PATH="${HELM_CHART_PATH:-"${1:-""}"}"
+HELM_VALUES="${HELM_VALUES:-"global.image.tag=${TEST_COMMIT_SHA},image.tag=${TEST_COMMIT_SHA},app.imageTag=${TEST_COMMIT_SHA}"}"
+HELM_VALUES_FILES="${HELM_VALUES_FILES:-""}"
+_KUBEVAL_PARAMS="${KUBEVAL_PARAMS:-"--ignore-missing-schemas"}"
+IFS="," read -r -a KUBEVAL_PARAMS <<< "${_KUBEVAL_PARAMS}"
+_KUBESCORE_PARAMS="${KUBESCORE_PARAMS:-"--ignore-container-cpu-limit,--ignore-container-memory-limit,--ignore-test=container-security-context-user-group-id,--ignore-test=container-security-context-privileged,--ignore-test=container-security-context-readonlyrootfilesystem,--ignore-test=pod-networkpolicy,--ignore-test=networkpolicy-targets-pod,--ignore-test=container-image-pull-policy,--ignore-test=cronjob-has-deadline"}"
+IFS="," read -r -a KUBESCORE_PARAMS <<< "${_KUBESCORE_PARAMS}"
+
+declare -a HELM_VALUES_FILES_GROUPS
+
+if [[ -z "$HELM_CHART_PATH" ]]; then
+	echo "ERROR: Missing \"HELM_CHART_PATH\" setting" >&2
+	exit 1
+fi
+
+###############################################################################
+# GOOGLE_APPLICATION_CREDENTIALS
+
+if [[ -n "$GCP_CREDENTIALS" ]]; then
+
+	if [[ -f "$GCP_CREDENTIALS" ]]; then
+		GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDENTIALS"
+	else
+		GOOGLE_APPLICATION_CREDENTIALS="/tmp/gac.$$.json"
+		echo "${GCP_CREDENTIALS}" > "$GOOGLE_APPLICATION_CREDENTIALS"
+	fi
+
+	export GOOGLE_APPLICATION_CREDENTIALS
+	echo "Activating service account: $(yq eval '.client_email' "$GOOGLE_APPLICATION_CREDENTIALS")"
+	/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS" || exit 2
+	echo "--"
+fi
+
+if [[ -n "$HELM_VALUES_FILES" ]]; then
+	echo "ℹ️  HELM_VALUES_FILES was specified by user"
+	echo "  📂 (from config): ${HELM_VALUES_FILES}"
+	HELM_VALUES_FILES_GROUPS=("$HELM_VALUES_FILES")
+else
+	echo "🔮 HELM_VALUES_FILES is empty -> autodetecting environments and value files"
+	HELM_VALUES_FILES_BASE="$(find "$HELM_CHART_PATH" -type f \! \( -path "*templates*" -or -path "*testing*" -or -path "*staging*" -or -path "*production*" \) -and \( -name "values.yaml" -or -name "values.yml" -or -name "secrets.yaml" -or -name "secrets.yml" -or -name "config.yaml" -or -name "config.yml" \) -print | sort -r | tr "\n" ",")"
+
+	for env in testing staging production; do
+		HELM_VALUES_FILES_ENV="$(find "$HELM_CHART_PATH" -type f -path "*${env}*" \! -path "templates" \( -name "*values*.yaml" -or -name "*values*.yml" -or -name "*secrets*.yaml" -or -name "*secrets*.yml" \) -print | sort -r | tr "\n" "," | sed 's/,$//')"
+
+		if [[ -n "$HELM_VALUES_FILES_ENV" ]]; then
+			echo "  📂 ${env}: ${HELM_VALUES_FILES_BASE}${HELM_VALUES_FILES_ENV}"
+			HELM_VALUES_FILES_GROUPS+=("${HELM_VALUES_FILES_BASE}${HELM_VALUES_FILES_ENV}")
+		fi
+	done
+
+	if [[ ${#HELM_VALUES_FILES_GROUPS[@]} -eq 0 ]]; then
+		if [[ -n "$HELM_VALUES_FILES_BASE" ]]; then
+			# shellcheck disable=SC2001
+			HELM_VALUES_FILES_BASE="$(echo "$HELM_VALUES_FILES_BASE" | sed 's/,$//')"
+			echo "  📂 (no env): ${HELM_VALUES_FILES_BASE}"
+			HELM_VALUES_FILES_GROUPS=("$HELM_VALUES_FILES_BASE")
+		else
+			echo "⚠️  No helm value files were found!"
+		fi
+	fi
+fi
+
+function helm_template_params() {
+	local -a helm_values_files="$1"  # comma-separated
+	local -a values_files
+	local -a params
+
+	IFS="," read -r -a values_files <<< "${helm_values_files}"
+
+	if [[ -n "$HELM_VALUES" ]]; then
+		params+=("--set-string")
+		params+=("$HELM_VALUES")
+	fi
+
+	for i in "${values_files[@]}"; do
+		params+=("--values")
+		params+=("$i")
+	done
+
+	echo "${params[*]}"
+}
+
+# Required for helm secrets template to print yamls only
+export HELM_SECRETS_QUIET="true"
+
+for files in "${HELM_VALUES_FILES_GROUPS[@]}"; do
+	echo
+	echo "📂👇 Checking ${HELM_CHART_PATH} with values from: ${files}"
+	rm -f /tmp/helm.out
+
+	helm_params="$(helm_template_params "$files")"
+	echo "  🧩 helm secrets template ${HELM_CHART_PATH} ${helm_params}"
+
+	# shellcheck disable=SC2086
+	if ! helm secrets template "${HELM_CHART_PATH}" ${helm_params} > /tmp/helm.out 2> /tmp/helm.err; then
+		cat /tmp/helm.out 
+		cat /tmp/helm.err >&2
+		echo "‼️  \"helm secrets template\" failed!"
+		exit 61
+	fi
+
+	echo "  🔦 kubeval --quiet --force-color --kubernetes-version ${KUBERNETES_VERSION}.0 ${KUBEVAL_PARAMS[*]}"
+	kubeval --quiet --force-color --kubernetes-version "${KUBERNETES_VERSION}.0" "${KUBEVAL_PARAMS[@]}" /tmp/helm.out || exit 62
+
+	echo "  💎 kube-score score --kubernetes-version v${KUBERNETES_VERSION} ${KUBESCORE_PARAMS[*]}"
+	kube-score score --kubernetes-version "v${KUBERNETES_VERSION}" "${KUBESCORE_PARAMS[@]}" /tmp/helm.out || exit 63
+done
+
+echo "👆"
+echo "--"


### PR DESCRIPTION
Migrate the helm-check command from Drone to GitHub Actions.

usage is as easy as

```
    - name: helm-check
      uses: GlobalWebIndex/github-actions/helm-check
      env:
        HELM_CHART_PATH: <path to Helm chart>
        GCP_CREDENTIALS: <service account to be used in case KMS support is needed>
```

Please see README.md for additional info.