### PR TITLE
Add helm deploy action

### DIFF
--- a/helm-deploy/Dockerfile
+++ b/helm-deploy/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcr.io/gwi-host-net/drone-helm:v1
+
+LABEL version="1.0.0"
+LABEL repository="https://github.com/GlobalWebIndex/github-actions"
+LABEL maintainer="GWI's DevOps team"
+
+LABEL com.github.actions.name="GitHub Action for Helm deploy"
+LABEL com.github.actions.description="Deploys an application on a GKE cluster, using helm secrets"
+LABEL com.github.actions.icon="cloud"
+LABEL com.github.actions.color="blue"
+
+ADD entrypoint.sh /entrypoint.sh
+CMD ["bash", "/entrypoint.sh"]

--- a/helm-deploy/README.md
+++ b/helm-deploy/README.md
@@ -1,0 +1,58 @@
+# Helm deploy GA plugin
+
+## What it does
+It deploys your Helm chart on a GKE cluster
+
+## Usage
+
+Just use the following environmental variables as inputs
+ > Either `GKE_REGION` or `GKE_ZONE` are needed
+
+```sh
+# Required
+GCP_CREDENTIALS: The service account in GCP to be used
+GKE_PROJECT: The name of your GKE project
+GKE_CLUSTER_NAME: The name of your cluster
+GKE_REGION: the region of your cluster
+GKE_ZONE: the zone of your cluster
+HELM_CHART_PATH: The path of your Helm chart
+
+# Optional
+HELM_TIMEOUT: how many seconds until Helm times out, default: 600s
+HELM_HISTORY_MAX: The max value of Helm\'s history, default: 30
+HELM_RELEASE_NAMESPACE: The namespace where your application will be deployed, default: "default"
+HELM_RELEASE_NAME: The name of your release, default: the foldername of the helm chart
+HELM_VALUES: Comma separated Values passed to Hlem through the --set-string attribute, default: ""
+HELM_VALUES_FILES: Comma separated value files for your Helm charts, default: ""
+```
+
+## Usage example
+```sh
+jobs:
+  helm_deploy:
+    runs-on: [ <tags for your self hosted runners> ]
+    container:
+      image: ghcr.io/catthehacker/ubuntu:act-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: helm-deploy
+      uses: GlobalWebIndex/github-actions/helm-deploy
+      env:
+        HELM_CHART_PATH: <path to your helm charts>
+        GCP_CREDENTIALS: ${{ secrets.SA_NAME}}
+        GKE_PROJECT: <your project in GKE>
+        GKE_CLUSTER_NAME: <the name of your cluster on GKE>
+        GKE_ZONE: europe-west1-b
+        HELM_VALUES: image.tag=demo
+        HELM_VALUES_FILES: <values-file.yaml>, <values-file-2.yaml>
+```
+
+## Test it locally
+
+In your local repo, create `./.github/workflows/main.yml` and add the code from the example above, making sure you fill all the required info. Then run the following command in order to test this with [act](https://github.com/nektos/act)
+
+```sh
+act --container-architecture linux/amd64 -s GITHUB_TOKEN -s SA_NAME --workflows ./.github/workflows/main.yml
+```

--- a/helm-deploy/entrypoint.sh
+++ b/helm-deploy/entrypoint.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "$GCP_CREDENTIALS" ]]; then
+
+	if [[ -f "$GCP_CREDENTIALS" ]]; then
+		GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDENTIALS"
+	else
+		GOOGLE_APPLICATION_CREDENTIALS="/tmp/gac.$$.json"
+		echo "${GCP_CREDENTIALS}" > "$GOOGLE_APPLICATION_CREDENTIALS"
+	fi
+
+	export GOOGLE_APPLICATION_CREDENTIALS
+	echo "Activating service account: $(yq eval '.client_email' "$GOOGLE_APPLICATION_CREDENTIALS")"
+	/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS" || exit 2
+	echo "--"
+fi
+
+###############################################################################
+# GKE
+GKE_PROJECT="${GKE_PROJECT:-${GCP_PROJECT:-""}}"
+
+if [[ -z "$HELM_CHART_PATH" ]]; then
+	echo "ERROR: Missing \"HELM_CHART_PATH\" setting" >&2
+	exit 1
+fi
+
+if [[ -z "$GKE_CLUSTER_NAME" || -z "$GKE_PROJECT" ]]; then
+	echo "ERROR: Missing \"GKE_CLUSTER_NAME\" and/or \"GKE_PROJECT\" settings" >&2
+	exit 1
+fi
+
+if [[ -z "$GKE_REGION" && -z "$GKE_ZONE" ]]; then
+	echo "ERROR: Missing \"GKE_REGION\" or \"GKE_ZONE\" setting" >&2
+	exit 1
+fi
+
+# If both options are specified then we will try both
+# this is a helper variable for tracking the result
+cluster_setup=1337
+
+if [[ -n "$GKE_ZONE" ]]; then
+	set +e
+	set -x
+	/google-cloud-sdk/bin/gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --project="$GKE_PROJECT" --zone="$GKE_ZONE"
+	cluster_setup=$?
+	{ set +x; set -e; } 2>/dev/null
+fi
+
+if [[ -n "$GKE_REGION" && "$cluster_setup" -ne 0 ]]; then
+	set +e
+	set -x
+	/google-cloud-sdk/bin/gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --project="$GKE_PROJECT" --region="$GKE_REGION"
+	cluster_setup=$?
+	{ set +x; set -e; } 2>/dev/null
+fi
+
+if [[ "$cluster_setup" -ne 0 ]]; then
+	echo "ERROR: Failed to fetch credentials for a GKE cluster" >&2
+	exit 3
+fi
+
+echo "--"
+###############################################################################
+# Helm2 and Helm commit parameters setup
+HELM_TIMEOUT="${HELM_TIMEOUT:-600s}"
+HELM_HISTORY_MAX="${HELM_HISTORY_MAX:-30}"
+HELM_RELEASE_NAMESPACE="${HELM_RELEASE_NAMESPACE:-"default"}"
+HELM_CHART_PATH="${HELM_CHART_PATH:-"${1:-""}"}"
+HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-""}"
+declare -a HELM_PARAMS=(
+	"--cleanup-on-fail"
+	"--history-max" "$HELM_HISTORY_MAX"
+)
+HELM_VALUES="${HELM_VALUES:-""}"
+IFS=$',' read -r -a HELM_VALUES_FILES <<< "$HELM_VALUES_FILES"
+
+if [[ -z "$HELM_RELEASE_NAME" ]]; then
+	HELM_CHART_DIR="$(cd "$HELM_CHART_PATH" || exit 64 ; pwd -P)"
+	HELM_RELEASE_NAME="$(basename "$HELM_CHART_DIR")"
+fi
+
+for i in "${HELM_VALUES_FILES[@]}"; do
+	HELM_PARAMS+=("--values")
+	HELM_PARAMS+=("$(echo "$i" | sed 's/[[:space:]]//g')") # empty any space
+done
+
+if [[ -n "$HELM_VALUES" ]]; then
+	HELM_PARAMS+=("--set-string")
+	HELM_PARAMS+=("$HELM_VALUES")
+fi
+
+export HELM_SECRETS_QUIET="true"
+
+####################################################
+#run
+echo "👇"
+set -x
+
+#helm3 update or new install
+if ! /usr/local/bin/helm secrets upgrade --install "${HELM_PARAMS[@]}" --timeout "$HELM_TIMEOUT" --namespace "$HELM_RELEASE_NAMESPACE" "$HELM_RELEASE_NAME" "$HELM_CHART_PATH"; then
+	{ set +x; } 2>/dev/null
+	echo "‼️  ERROR: helm upgrade command has failed; \"${HELM_RELEASE_NAME}\" was not updated/installed." >&2
+	exit 42
+fi
+
+{ set +x; } 2>/dev/null
+echo "👆"
+echo "--"


### PR DESCRIPTION
Migrate the helm-deploy command from Drone to GitHub Actions.

usage is as easy as
```
    - name: helm-check
      uses: GlobalWebIndex/github-actions/helm-deploy
      env:
        HELM_CHART_PATH: <path to helm chart>
        GCP_CREDENTIALS: <service account to be used in case KMS support is needed>
        GKE_PROJECT:  <gke project>
        GKE_CLUSTER_NAME: <gke cluster name>
        GKE_ZONE: <gke zone>
        HELM_VALUES_FILES: <Comma separated value files for your Helm charts>
```